### PR TITLE
Working refactor, added factory tests

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -99,35 +99,42 @@ class Client implements ClientInterface
         );
     }
 
+    public function requestFactory($method, $uri = null, array $options = [])
+    {
+        $request = $this->prepareRequest($method, $uri, $options);
+
+        return $this->applyOptions($request, $options);
+    }
+
     public function send(RequestInterface $request, array $options = [])
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
         return $this->sendAsync($request, $options)->wait();
     }
 
-    public function requestFactory($method, $uri = null, array $options = [])
+    private function prepareRequest($method, $uri = null, array &$options = [])
     {
-        // Remove request modifying parameter because it can be done up-front.
+        $options = $this->prepareDefaults($options);
         $headers = isset($options['headers']) ? $options['headers'] : [];
+
         $body = isset($options['body']) ? $options['body'] : null;
-        $version = isset($options['version']) ? $options['version'] : '1.1';
-        // Merge the URI into the base URI.
-        $uri = $this->buildUri($uri, $options);
         if (is_array($body)) {
             $this->invalidBody();
         }
-        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
-        // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
 
-        return $this->applyOptions($request, $options);
+        // Merge the URI into the base URI.
+        $uri = $this->buildUri($uri, $options);
+
+        $version = isset($options['version']) ? $options['version'] : '1.1';
+        return new Psr7\Request($method, $uri, $headers, $body, $version);
     }
 
     public function requestAsync($method, $uri = null, array $options = [])
     {
-        $request = $this->requestFactory($method, $uri, $options);
-        $options = $this->prepareDefaults($options);
+        $request = $this->prepareRequest($method, $uri, $options);
 
+        // Remove the option so that they are not doubly-applied.
+        unset($options['headers'], $options['body'], $options['version']);
         return $this->transfer($request, $options);
     }
 
@@ -252,7 +259,7 @@ class Client implements ClientInterface
      *
      * @return Promise\PromiseInterface
      */
-    private function transfer(RequestInterface $request, array $options = [])
+    private function transfer(RequestInterface $request, array $options)
     {
         // save_to -> sink
         if (isset($options['save_to'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -509,6 +509,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['baz'], $request->getHeader('bar'));
     }
 
+    public function testSendingRequestFactoryInstance()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $request = $client->requestFactory('GET', 'http://foo.com', [
+            'headers'  => ['bar' => 'baz'],
+            'query' => ['foo' => 'bar', 'john' => 'doe'],
+        ]);
+
+        $response = $client->send($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     public function testRequestFactoryHeaders()
     {
         $client = new Client();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -493,4 +493,42 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
         $this->assertEquals('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
     }
+
+    public function testRequestFactory()
+    {
+        $client = new Client([
+            'base_uri' => 'http://foo.com',
+            'headers'  => ['bar' => 'baz'],
+        ]);
+
+        $request = $client->requestFactory('GET', 'http://foo.com', [
+            'query' => ['foo' => 'bar', 'john' => 'doe'],
+        ]);
+
+        $this->assertEquals('foo=bar&john=doe', $request->getUri()->getQuery());
+        $this->assertEquals(['baz'], $request->getHeader('bar'));
+    }
+
+    public function testRequestFactoryHeaders()
+    {
+        $client = new Client();
+
+        $request = $client->requestFactory('GET', 'http://foo.com', [
+            'headers'  => ['bar' => 'baz'],
+        ]);
+
+        $this->assertEquals(['baz'], $request->getHeader('bar'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRequestFactoryInvalidBody()
+    {
+        $client = new Client();
+
+        $client->requestFactory('GET', 'http://foo.com', [
+            'body' => ['foo' => 'bar', 'john' => 'doe'],
+        ]);
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -514,10 +514,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
 
-        $request = $client->requestFactory('GET', 'http://foo.com', [
-            'headers'  => ['bar' => 'baz'],
-            'query' => ['foo' => 'bar', 'john' => 'doe'],
-        ]);
+        $request = $client->requestFactory('GET', 'http://foo.com');
 
         $response = $client->send($request);
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
This branch is an attempt to fix the current broken state of PR #1101. I have refactored `requestFactory` to produce a configured `Request`, while preserving the functionality of `requestAsync`. 

I have also added 3 tests that demonstrate a working factory, preserved functionality, and coverage.